### PR TITLE
:sparkles:Add download modal for analysis details reports

### DIFF
--- a/client/src/app/pages/applications/applications-table/applications-table.tsx
+++ b/client/src/app/pages/applications/applications-table/applications-table.tsx
@@ -16,8 +16,10 @@ import {
   DropdownItem,
   Modal,
   Tooltip,
+  FormGroup,
 } from "@patternfly/react-core";
 import {
+  CodeIcon,
   PencilAltIcon,
   TagIcon,
   WarningTriangleIcon,
@@ -1357,6 +1359,35 @@ export const ApplicationsTable: React.FC = () => {
           }}
         />
       </div>
+      <Modal
+        isOpen={isDownloadModalOpen}
+        variant="small"
+        title={t("actions.download", { what: "analysis details reports" })}
+        onClose={() => setIsDownloadModalOpen(false)} // סגור את המודל
+      >
+        <FormGroup label="Select Format" fieldId="format-select">
+          <div>
+            <Button
+              variant={selectedFormat === "json" ? "primary" : "secondary"}
+              onClick={() => setSelectedFormat("json")}
+            >
+              {<CodeIcon />}
+              JSON
+            </Button>
+            <Button
+              variant={selectedFormat === "yaml" ? "primary" : "secondary"}
+              onClick={() => setSelectedFormat("yaml")}
+            >
+              {<CodeIcon />}
+              YAML
+            </Button>
+          </div>
+          <p>Selected Format: {selectedFormat}</p>
+        </FormGroup>
+        <Button variant="primary" onClick={handleDownload}>
+          {t("actions.download")}
+        </Button>
+      </Modal>
     </ConditionalRender>
   );
 };


### PR DESCRIPTION
Implement download modal for analysis details reports. 
Added buttons to select between JSON and YAML formats, 
and displayed the selected format. 